### PR TITLE
Update to 1.3.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "sniffio" %}
-{% set version = "1.2.0" %}
+{% set version = "1.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,35 +7,42 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de
+  sha256: e60305c5e5d314f5389259b7f22aaa33d8f7dee49763119234af3755c55b9101
 
 build:
-  number: 1
-  skip: true  # [py<35]
-  script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv '
+  number: 0
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
-  build:
-    - python                                 # [build_platform != target_platform]
   host:
     - pip
     - python
+    - setuptools
+    - wheel
   run:
     - python
-    - contextvars >=2.1  # [py<37]
 
 test:
   imports:
     - sniffio
     - sniffio._tests
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://github.com/python-trio/sniffio
-  license: Apache-2.0
-  license_family: Apache
-  license_file: LICENSE.APACHE2
+  license: MIT OR Apache-2.0
+  license_file:
+    - LICENSE.APACHE2
+    - LICENSE.MIT
+    - LICENSE
+  license_family: Other
   summary: Sniff out which async library your code is running under
   doc_url: https://sniffio.readthedocs.io
+  dev_url: https://github.com/python-trio/sniffio
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Changes:
- Update to 1.3.0 (required for trio update)

https://github.com/python-trio/sniffio/tree/v1.3.0